### PR TITLE
refactor: simplify kurup lookup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,11 +34,13 @@ async function cariKurupTaun(_q: number): Promise<TaunKurupType> {
   const _qi = parseInt(_q.toString());
   return new Promise((resolve, reject) => {
     for (const _kurup of Kurup.KURUP_ASAPON_ANENHING) {
-      _kurup.awal.find(query => {
-        if (query === _qi) resolve(_kurup);
-      });
+      for (const query of _kurup.awal) {
+        if (query === _qi) {
+          resolve(_kurup);
+          return;
+        }
+      }
     }
-
     reject(new Error('Error cariKurupTaun'));
   });
 }


### PR DESCRIPTION
## Summary
- avoid redundant rejection when searching for kurup by iterating explicitly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1bb0f7dc832aa624bc35d3d5c92e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Performance
  * Improved search responsiveness by stopping as soon as a match is found, reducing unnecessary work. Users should see faster results when looking up kurup years, especially with larger datasets.
* Refactor
  * Streamlined internal search logic for clarity and efficiency with no changes to public APIs or results. Behavior remains identical; error handling is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->